### PR TITLE
Policy Domain Assignment in File.

### DIFF
--- a/Ryu_Application/aclswitch/aclswitch.py
+++ b/Ryu_Application/aclswitch/aclswitch.py
@@ -95,17 +95,21 @@ class ACLSwitch(ABCRyuApp):
         self._flow_man = FlowManager(self, logging_config)
         self._api = ACLSwitchAPI(logging_config, self._VERSION,
                                  self._flow_man)
-
         self._api.policy_create(self._POLICY_DEFAULT)
 
         # Read config files
         # TODO Command line argument for custom location for config file
-        policies = self._config.load_policies()
+        policies, pd_assignments = self._config.load_policies()
         rules = self._config.load_rules()
         for pol in policies:
             self._api.policy_create(pol)
         for rule in rules:
             self._api.acl_create_rule(rule)
+        for assignment in pd_assignments:
+            self._api.switch_register(assignment["switch_id"])
+            self._api.policy_assign_switch(assignment["switch_id"],
+                                           assignment["policy"],
+                                           from_file=True)
 
         # Register REST WSGI through the controller app
         self._contr.register_rest_wsgi(ACLSwitchREST, kwargs={
@@ -263,9 +267,12 @@ class ACLSwitch(ABCRyuApp):
         self._contr.add_flow(datapath, 1, match, inst, 0,
                              self._table_id_whitelist)
 
-        # Take note of switches (via their datapaths IDs)
-        self._api.switch_connect(datapath_id)
+        # Registered the switch, assign the default policy, then set
+        # to a connected state. Once connected, the rules will be sent
+        # to the switch.
+        self._api.switch_register(datapath_id)
         self._api.policy_assign_switch(datapath_id, self._POLICY_DEFAULT)
+        self._api.switch_connect(datapath_id)
 
     def get_app_name(self):
         return self._APP_NAME

--- a/Ryu_Application/aclswitch/config/policy_domains.yaml
+++ b/Ryu_Application/aclswitch/config/policy_domains.yaml
@@ -14,5 +14,7 @@ policy_domains:
   - "test2"
 
 pd_assignments:
-  dp1: "test1"
-  dp2: "test2"
+  - switch_id: 1
+    policy: "test1"
+  - switch_id: 2
+    policy: "test2"

--- a/Ryu_Application/aclswitch/config_loader.py
+++ b/Ryu_Application/aclswitch/config_loader.py
@@ -94,11 +94,16 @@ class ConfigLoader:
         if pd_yaml["pd_assignments"] is not None:
             for assignment in pd_yaml["pd_assignments"]:
                 if assignment is not None:
+                    if not data_templates.check_policy_assign_json(
+                            assignment):
+                        self._logging.warning("%s is not formatted "
+                                              "correctly.", assignment)
+                        continue
                     self._logging.debug("Reading Policy Domain "
                                         "assignment: %s",
                                         str(assignment))
-                    pd_assignments.append(pd_assignments)
-        return policies  # TODO return PD assignments
+                    pd_assignments.append(assignment)
+        return policies, pd_assignments
 
     def load_rules(self):
         """Load the rules from file.
@@ -124,7 +129,8 @@ class ConfigLoader:
         if rule_yaml["acl_rules"] is not None:
             for rule in rule_yaml["acl_rules"]:
                 if not data_templates.check_rule_creation_json(rule):
-                    self._logging.warning("%s is not valid rule: ", rule)
+                    self._logging.warning("%s is not formatted "
+                                          "correctly.", rule)
                     continue
                 self._logging.debug("Reading ACL rule: %s", rule)
                 rules.append(rule)

--- a/Ryu_Application/aclswitch/data_templates.py
+++ b/Ryu_Application/aclswitch/data_templates.py
@@ -27,9 +27,9 @@ _POLICY_ASSIGN = ("switch_id", "policy")
 
 
 def check_rule_creation_json(rule):
-    """Check that rule creation JSON is formatted correctly.
+    """Check that rule creation data is formatted correctly.
 
-    :param rule: Rule JSON to check.
+    :param rule: Rule dict to check.
     :return: True if valid, False otherwise.
     """
     for key in _RULE_CREATE:
@@ -46,9 +46,9 @@ def check_rule_creation_json(rule):
 
 
 def check_rule_removal_json(rule):
-    """Check that rule removal JSON is formatted correctly.
+    """Check that rule removal data is formatted correctly.
 
-    :param rule: Rule JSON to check.
+    :param rule: Rule dict to check.
     :return: True if valid, False otherwise.
     """
     if len(rule) != len(_RULE_REMOVE):
@@ -60,10 +60,10 @@ def check_rule_removal_json(rule):
 
 
 def check_policy_json(policy):
-    """Check that policy domain creation JSON is formatted
+    """Check that policy domain creation data is formatted
     correctly. This can aso be used for policy domain removal.
 
-    :param policy: Policy JSON to check.
+    :param policy: Policy dict to check.
     :return: True if valid, False otherwise.
     """
     if len(policy) != len(_POLICY):
@@ -75,11 +75,11 @@ def check_policy_json(policy):
 
 
 def check_policy_assign_json(policy_assign):
-    """Check that policy domain assignment JSON is formatted
+    """Check that policy domain assignment data is formatted
     correctly. This can also be used for messages that revoke
     assignments.
 
-    :param policy_assign: Policy assignment JSON to check.
+    :param policy_assign: Policy assignment dict to check.
     :return: True if valid, False otherwise.
     """
     if len(policy_assign) != len(_POLICY_ASSIGN):

--- a/Ryu_Application/aclswitch/policy/policy_manager.py
+++ b/Ryu_Application/aclswitch/policy/policy_manager.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ACLSwitch modules
+from switch import Switch
+
 # Module imports
 import logging
 
@@ -33,7 +36,7 @@ class PolicyManager:
         self._logging.propagate = logging_config["propagate"]
         self._logging.addHandler(logging_config["handler"])
         self._logging.info("Initialising PolicyManager...")
-        self._connected_switches = {}  # switch_id_id:[policy]
+        self._switches = {}  # switch_id_id:switch
         self._policy_to_rules = {}  # policy:[rule_id]
 
     def policy_create(self, policy):
@@ -63,8 +66,8 @@ class PolicyManager:
                                   "not exist.", policy)
             return False
         # We must revoke the policy from switches that have it assigned
-        for switch_id in self._connected_switches:
-            if policy in self._connected_switches[switch_id]:
+        for switch_id in self._switches:
+            if policy in self._switches[switch_id]:
                 self.switch_revoke_policy(switch_id, policy)
         del self._policy_to_rules[policy]
         self._logging.info("Removed policy: %s", policy)
@@ -111,8 +114,8 @@ class PolicyManager:
         :return: List of switch IDs.
         """
         switches = []
-        for switch_id in self._connected_switches:
-            if policy in self._connected_switches[switch_id]:
+        for switch_id in self._switches:
+            if self._switches[switch_id].has_policy(policy):
                 switches.append(switch_id)
         return switches
 
@@ -136,21 +139,46 @@ class PolicyManager:
         self._logging.debug("Rule %s removed from policy %s.",
                             rule_id, policy)
 
+    def switch_register(self, switch_id):
+        """Register a switch with the policy manager.
+
+        Note that a switch may be registered but not connected.
+
+        :param switch_id: Switch identifier, typically the datapath ID.
+        :return: True if the switch has not registered before,
+        False otherwise.
+        """
+        if switch_id in self._switches:
+            self._logging.info("Switch %s already registered.",
+                               switch_id)
+            return False
+        self._switches[switch_id] = Switch(switch_id)
+        self._logging.info("Switch %s registered.", switch_id)
+        return True
+
     def switch_connect(self, switch_id):
         """Inform the policy manager that a switch has connected to
         the network.
 
         :param switch_id: Switch identifier, typically the datapath ID.
-        :return: True if the switch has not been recorded before,
+        :return: True if the switch has not connected before,
         False otherwise.
         """
-        if switch_id in self._connected_switches:
-            self._logging.warning("Switch %s already registered.",
-                                  switch_id)
+        if switch_id not in self._switches:
+            self._logging.info("Switch %s has not been registered.",
+                               switch_id)
             return False
-        self._connected_switches[switch_id] = []
-        self._logging.info("Switch %s registered.", switch_id)
+        self._switches[switch_id].set_connected(True)
+        self._logging.info("Switch %s connected.", switch_id)
         return True
+
+    def switch_is_connected(self, switch_id):
+        """Check if a switch is in a connected state.
+
+        :param switch_id: Switch identifier, typically the datapath ID.
+        :return: True if in connected state, False otherwise.
+        """
+        return self._switches[switch_id].is_connected()
 
     def switch_disconnect(self, switch_id):
         """Inform the policy manager that a switch has disconnected from
@@ -159,8 +187,9 @@ class PolicyManager:
         :param switch_id: Switch identifier, typically the datapath ID.
         :return: True if successful, False otherwise.
         """
-        del self._connected_switches[switch_id]
-        self._logging.info("Switch %s unregistered.", switch_id)
+        # TODO Have a configuration option specify if switch information be deleted on disconnect i.e. they get unregistered.
+        self._switches[switch_id].set_connected(False)
+        self._logging.info("Switch %s disconnected.", switch_id)
         return True
 
     def switch_exists(self, switch_id):
@@ -169,7 +198,7 @@ class PolicyManager:
         :param switch_id: Switch identifier, typically the datapath ID.
         :return: True if it exists, False otherwise.
         """
-        if switch_id in self._connected_switches:
+        if switch_id in self._switches:
             self._logging.debug("Switch %s exists.", switch_id)
             return True
         self._logging.warning("Switch %s does not exist.", switch_id)
@@ -183,11 +212,11 @@ class PolicyManager:
         :return: True if the policy wasn't already assigned,
         False otherwise.
         """
-        if policy in self._connected_switches[switch_id]:
-            self._logging.warning("Switch %s does already has policy "
-                                  "%s assigned.", switch_id, policy)
+        if self._switches[switch_id].has_policy(policy):
+            self._logging.warning("Switch %s already has policy %s "
+                                  "assigned.", switch_id, policy)
             return False
-        self._connected_switches[switch_id].append(policy)
+        self._switches[switch_id].policy_assign(policy)
         self._logging.info("Policy %s assigned to switch %s", policy,
                            switch_id)
         return True
@@ -199,14 +228,22 @@ class PolicyManager:
         :param policy: The policy to revoke.
         :return: True if successful, False otherwise.
         """
-        if policy not in self._connected_switches[switch_id]:
+        if not self._switches[switch_id].has_policy(policy):
             self._logging.warning("Switch %s does not have policy %s "
                                   "assigned.", switch_id, policy)
             return False
-        self._connected_switches[switch_id].remove(policy)
+        self._switches[switch_id].policy_revoke(policy)
         self._logging.info("Policy %s revoked from switch %s", policy,
                            switch_id)
         return True
+
+    def switch_get_policies(self, switch_id):
+        """Fetch the list of policy domains assigned to a switch.
+
+        :param switch_id: Switch identifier, typically the datapath ID.
+        :return: List of policy domains.
+        """
+        return self._switches[switch_id].get_policies()
 
     def get_all_policies(self):
         """Fetch and return a dict of policies and the rules that are
@@ -222,7 +259,11 @@ class PolicyManager:
 
         :return: A dict of switch IDs to a list of policies.
         """
-        return self._connected_switches
+        switch_pol = {}
+        for switch_id in self._switches:
+            switch_pol[switch_id] = self._switches[
+                switch_id].get_policies()
+        return switch_pol
 
     def get_num_policies(self):
         """Return the number of policy domains.
@@ -232,8 +273,8 @@ class PolicyManager:
         return len(self._policy_to_rules)
 
     def get_num_switches(self):
-        """Return the number of connected switches.
+        """Return the number of registered switches.
 
-        :return: The number of connected switches as an int.
+        :return: The number of registered switches as an int.
         """
-        return len(self._connected_switches)
+        return len(self._switches)

--- a/Ryu_Application/aclswitch/policy/switch.py
+++ b/Ryu_Application/aclswitch/policy/switch.py
@@ -50,7 +50,10 @@ class Switch:
         :param policy: The policy to revoke.
         :return: True if successful, False otherwise.
         """
-        pass
+        if policy not in self._policies:
+            return False
+        self._policies.remove(policy)
+        return True
 
     def get_policies(self):
         """Return the list of assigned policies for this switch.

--- a/Ryu_Application/aclswitch/policy/switch.py
+++ b/Ryu_Application/aclswitch/policy/switch.py
@@ -1,0 +1,92 @@
+# Copyright 2016 Jarrod N. Bakker
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__author__ = "Jarrod N. Bakker"
+__status__ = "Development"
+
+
+class Switch:
+    """An abstraction of a switch.
+    """
+
+    def __init__(self, switch_id):
+        """Initialise.
+
+        Set the switch into a registered but not connected state. A
+        switch has no assigned policies on creation.
+        :param switch_id: Switch identifier, typically the datapath ID.
+        """
+        self.switch_id = switch_id
+        self._registered = True
+        self._connected = False
+        self._policies = []
+
+    def policy_assign(self, policy):
+        """Assign a policy domain to this switch.
+
+        :param policy: The policy to assign.
+        :return: True if the policy wasn't already assigned,
+        False otherwise.
+        """
+        if policy in self._policies:
+            return False
+        self._policies.append(policy)
+        return True
+
+    def policy_revoke(self, policy):
+        """Revoke a policy domain from this switch.
+
+        :param policy: The policy to revoke.
+        :return: True if successful, False otherwise.
+        """
+        pass
+
+    def get_policies(self):
+        """Return the list of assigned policies for this switch.
+
+        :return: List of policy domain names.
+        """
+        return self._policies
+
+    def has_policy(self, policy):
+        """Check if a policy has been assigned to this switch.
+
+        :param policy: The policy to check.
+        :return: True is assigned, False otherwise.
+        """
+        return policy in self._policies
+
+    def is_registered(self):
+        """Inform the caller if the switch is in a registered state.
+
+        :return: the _connected field for the object.
+        """
+        return self._registered
+
+    def is_connected(self):
+        """Inform the caller if the switch is in a connected state.
+
+        :return: the _connected field for the object.
+        """
+        return self._connected
+
+    def set_connected(self, connected):
+        """Change the connected status of a switch.
+
+        :param connected: True if the switch is connecting, False if
+        it is disconnecting.
+        :return: True if successful, False otherwise.
+        """
+        self._connected = connected
+        return True


### PR DESCRIPTION
Policy Domains can be assigned to a switch using the policy_domains.yaml file. Changes were made to the PolicyManager to cope a new switch class that keeps track of switch state. The REST WSGI cannot inform ACLSwitch about switches that don't exist, this can only be done via the policy_domains.yaml file.
